### PR TITLE
Build updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tags
 *.in
 *.exe
 test/*
+result

--- a/cake3.cabal
+++ b/cake3.cabal
@@ -100,7 +100,7 @@ executable urembed
                      text, bytestring, containers,
                      haskell-src-meta, template-haskell, attoparsec, monadloc,
                      mime-types, parsec, transformers, utf8-string,
-                     blaze-builder, array
+                     blaze-builder, array, pretty, c-dsl
   other-modules:     C
                      C_DSL
                      CSS

--- a/cake3.nix
+++ b/cake3.nix
@@ -1,0 +1,28 @@
+{ mkDerivation, array, attoparsec, base, blaze-builder, bytestring
+, containers, deepseq, directory, filepath, haskell-src-meta
+, mime-types, monadloc, mtl, optparse-applicative, parsec, process
+, stdenv, syb, system-filepath, template-haskell, text, text-format
+, transformers, utf8-string
+}:
+mkDerivation {
+  pname = "cake3";
+  version = "0.6.5";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    attoparsec base bytestring containers deepseq directory filepath
+    haskell-src-meta mime-types monadloc mtl parsec process syb
+    system-filepath template-haskell text text-format
+  ];
+  executableHaskellDepends = [
+    array attoparsec base blaze-builder bytestring containers directory
+    filepath haskell-src-meta mime-types monadloc mtl
+    optparse-applicative parsec process syb template-haskell text
+    transformers utf8-string
+  ];
+  homepage = "https://github.com/grwlf/cake3";
+  description = "Third cake the Makefile EDSL";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs.haskell.lib;
+let
+  c-dsl = doJailbreak pkgs.haskellPackages.c-dsl;
+in
+addBuildDepends (pkgs.haskellPackages.callPackage ./cake3.nix {})
+  (with pkgs.haskellPackages; [alex happy c-dsl])
+


### PR DESCRIPTION
- Adds two missing dependencies (`c-dsl`, `pretty`)
- Adds nix build scripts (compatible w/ `GHC-8.2.2`)
- Jailbreaks `c-dsl` due to its hard constraint on `language-c == 0.4`